### PR TITLE
Removed invalid preprocessing directive

### DIFF
--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -214,7 +214,6 @@ Value listunspent(const Array& params, bool fHelp)
             CTxDestination address;
             if (ExtractDestination(pk, address))
             {
-                #const CScriptID& hash = boost::get<const CScriptID&>(address);
                 const CScriptID& hash = boost::get<CScriptID>(address);
                 CScript redeemScript;
                 if (pwalletMain->GetCScript(hash, redeemScript))


### PR DESCRIPTION
I could see that you had tried to comment that line out but I feel it is best to remove it in order to properly support boost 1.58